### PR TITLE
Add Time Machine speedup/down scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 | `hidefiles`              | Hide hidden files in Finder                           |
 | `rmdsstore`              | Remove .DS_Store files recursively in a directory     |
 | `showfiles`              | Show hidden files in Finder                           |
+| speedup_timemachine    | Run Time Machine backups with normal user priority    |
+| speeddown_timemachine  | Run Time Machine backups with lower priority again    |
 | `create_macos_bootstick` | Create a bootable memory stick from a macOS Installer |
 | `music`                  | CLI script to control Music application               |
 | `tadd`                   | Add currently playing track to playlist               |

--- a/functions/speeddown_timemachine
+++ b/functions/speeddown_timemachine
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+
+# See https://www.defaults-write.com/speed-up-time-machine-backups/
+sudo sysctl debug.lowpri_throttle_enabled=1

--- a/functions/speedup_timemachine
+++ b/functions/speedup_timemachine
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+
+# https://www.defaults-write.com/speed-up-time-machine-backups/
+sudo sysctl debug.lowpri_throttle_enabled=0


### PR DESCRIPTION
The speed-up script turns off throttling for Time Machine backup while
the other script will turn it on again.

Fixes #5
